### PR TITLE
small change to avoid bug loading config

### DIFF
--- a/fence/config-default.yaml
+++ b/fence/config-default.yaml
@@ -573,7 +573,7 @@ dbGaP:
     #
     # If `parse_consent_code` is true, then a user will be given access to the exact
     # same consent codes in the child studies
-    parent_to_child_studies_mapping:
+    parent_to_child_studies_mapping: {}
       # 'phs001194': ['phs000571', 'phs001843']
     # A consent of "c999" can indicate access to that study's "exchange area data"
     # and when a user has access to one study's exchange area data, they


### PR DESCRIPTION
I have encountered this error when working on the other cloud automation tickets but when parent_to_child_studies_mapping is left blank its value is converted to None during yaml_merge so this line when creating the config parent_studies = dbgap_config.get("parent_to_child_studies_mapping", {}).keys() throws an error cause None has no keys. Let me know what you think I see this line in the fence-config in gearbox-dev and portal-dev was removed to avoid the error