### PR TITLE
fix bug in GET /user/admin/user/<email>

### DIFF
--- a/fence/resources/user/__init__.py
+++ b/fence/resources/user/__init__.py
@@ -153,7 +153,7 @@ def get_user_info(current_session, username):
         "resources_granted": [],
         "groups": groups,
         "message": "",
-        "docs_to_be_reviewed": project_schema.dump(get_doc_to_be_reviewed(current_session))
+        "docs_to_be_reviewed": project_schema.dump(udm.get_doc_to_review(current_session, user.username)),
     }
 
     if "fence_idp" in flask.session:


### PR DESCRIPTION
The error was caused by the admin endpoints not setting flask.g.user which would throw the attribute error also since were sending another users email we dont want to use flask.g.user here. The solution here is to just call udm.get_doc_to_review instead of the middleware function get_doc_to_be_reviewed. An alternative solution would be to alter get_doc_to_be_reviewed to allow for a username parameter to be passed and default to flask.g.user.username but since get_doc_to_be_reviewed is being used in non admin endpoints this could potential open the door in the future to a user endpoint allowing for the username parameter to be passed by mistake and then users can send other users emails.