### PR TITLE
PEDS-1621 Remove client policy endpoing created

### DIFF
--- a/fence/blueprints/admin.py
+++ b/fence/blueprints/admin.py
@@ -817,6 +817,53 @@ def add_policies_to_client():
 
     return jsonify("Success")
 
+@blueprint.route("/remove_policies_from_client", methods=["POST"])
+@admin_login_required
+@enable_request_logging
+def remove_policies_from_client():
+    '''
+    payload:
+    `{
+       "policy_names" = ["services.amanuensis-admin", "data_admin"],
+       "client_id" = "akjsdhoadoadshaouhasod1!"
+    }`
+    '''
+    body = request.get_json()
+    policy_names = body.get('policy_names', None)
+    client_id = body.get('client_id', None)
+    if client_id is None or policy_names is None or len(policy_names) < 1:
+        raise UserError("There are some missing parameters in the payload.")
+
+    try:
+        x = current_app.arborist.get_client(client_id)
+        current_policies = x['policies']
+        to_keep = list(set(current_policies) - set(policy_names))
+        current_app.arborist.update_client(client_id, to_keep)
+    except ArboristError as e:
+        current_app.logger.error(
+            "Failed to revoke policies `{}` from client `{}`: {}".format(
+                policy_names, client_id, str(e)
+            )
+        )
+        raise ArboristError(
+            "Error revoking policies from client {}".format(
+                client_id
+            )
+        )
+    
+    return jsonify("Success")
+
+
+@blueprint.route("/clients", methods=["GET"])
+@admin_login_required
+@enable_request_logging
+def get_all_clients():
+    """
+    Get the information of all clients from our database
+
+    Returns a json object.
+    """
+    return jsonify(admin.get_all_clients(current_app.scoped_session()))
 
 
 #### PROJECTS ####

--- a/fence/blueprints/admin.py
+++ b/fence/blueprints/admin.py
@@ -835,8 +835,8 @@ def remove_policies_from_client():
         raise UserError("There are some missing parameters in the payload.")
 
     try:
-        x = current_app.arborist.get_client(client_id)
-        current_policies = x['policies']
+        client = current_app.arborist.get_client(client_id)
+        current_policies = client['policies']
         to_keep = list(set(current_policies) - set(policy_names))
         current_app.arborist.update_client(client_id, to_keep)
     except ArboristError as e:

--- a/fence/blueprints/admin.py
+++ b/fence/blueprints/admin.py
@@ -854,18 +854,6 @@ def remove_policies_from_client():
     return jsonify("Success")
 
 
-@blueprint.route("/clients", methods=["GET"])
-@admin_login_required
-@enable_request_logging
-def get_all_clients():
-    """
-    Get the information of all clients from our database
-
-    Returns a json object.
-    """
-    return jsonify(admin.get_all_clients(current_app.scoped_session()))
-
-
 #### PROJECTS ####
 @blueprint.route("/projects/<projectname>", methods=["GET"])
 @admin_login_required

--- a/poetry.lock
+++ b/poetry.lock
@@ -1880,19 +1880,23 @@ name = "gen3authz"
 version = "3.1.1"
 description = "Gen3 authz client"
 optional = false
-python-versions = "<4.0,>=3.13"
+python-versions = ">=3.13,<4.0"
 groups = ["main"]
-files = [
-    {file = "gen3authz-3.1.1-py3-none-any.whl", hash = "sha256:5223cdf841900ca9ca3c445a8cf4d12a90f73b0cb0a4450491dca42f3c020340"},
-    {file = "gen3authz-3.1.1.tar.gz", hash = "sha256:6bd36e1a6cb5b5141a9ea388ee33398fa7fd777b10f91386c5e28d946a18b505"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 backoff = ">=2.2.1,<3.0.0"
 cdiserrors = "<3.0.0"
 httpx = ">=0.20.0,<1.0.0"
-six = ">=1.16.0,<2.0.0"
+six = "^1.16.0"
 sniffio = ">=1.3.1"
+
+[package.source]
+type = "git"
+url = "https://github.com/chicagopcdc/gen3authz"
+reference = "master"
+resolved_reference = "4780d2c1e9b2569e6dd007072c2dcfa7f047ba21"
 
 [[package]]
 name = "gen3cirrus"
@@ -5295,4 +5299,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0.0"
-content-hash = "ea1d3691831bf310d42cd61c1c1a94ed34533c129c7fcec1b333554992d58c83"
+content-hash = "3676479516362add481e9e0a71087654875cfc3139546875bc8eaf943a01b2e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ cryptography = ">=44.0.1"
 flask-cors = "<7"
 flask-restful = ">=0.3.8"
 email_validator = ">=1.1.1"
-gen3authz = ">=3.1.0"
+gen3authz = {git = "https://github.com/chicagopcdc/gen3authz", rev = "master"}
 gen3cirrus = ">=4.0.1"
 gen3config = "<3"
 gen3users = ">=1.0.2"


### PR DESCRIPTION
This pull request was created to add an endpoint for removing policies from a client following a specific payload. Utilizes already present update_client feature in its functionality. Ensures both client_id and policy_names are fulfilled and properly formatted and the success of a request to revoke a policy.

Requires changes made in: https://github.com/chicagopcdc/gen3authz/pull/2